### PR TITLE
"is.function" will throw a syntax error in older browsers, because in ES...

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ As a component
 
 ### function
 
- - function (value)
+ - is.function(value)
+ - is.aFunction(value) - for ES3 browsers, where "function" is a reserved word
 
 ### number
 

--- a/index.js
+++ b/index.js
@@ -369,7 +369,7 @@ is.error = function (value) {
  */
 
 /**
- * is.function
+ * is.function / is.aFunction
  * Test if `value` is a function.
  *
  * @param {Mixed} value value to test
@@ -377,7 +377,7 @@ is.error = function (value) {
  * @api public
  */
 
-is.function = function(value) {
+is['function'] = is.aFunction = function(value) {
   return '[object Function]' === toString.call(value);
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -198,14 +198,15 @@ test('is.error', function (t) {
 });
 
 test('is.function', function (t) {
-  t.true(is.function(function () {}), 'function is function');
-  t.true(is.function(console.log), 'console.log is function');
+  t.equal(is['function'], is.aFunction, 'alias works');
+  t.true(is.aFunction(function () {}), 'function is function');
+  t.true(is.aFunction(console.log), 'console.log is function');
   if (typeof window !== 'undefined') {
     // in IE7/8, typeof alert === 'object'
-    t.true(is.function(window.alert), 'window.alert is function');
+    t.true(is.aFunction(window.alert), 'window.alert is function');
   }
-  t.false(is.function({}), 'object is not function');
-  t.false(is.function(null), 'null is not function');
+  t.false(is.aFunction({}), 'object is not function');
+  t.false(is.aFunction(null), 'null is not function');
   t.end();
 });
 


### PR DESCRIPTION
"is.function" will throw a syntax error in older browsers, because in ES3, "function" is a reserved word.
