### PR TITLE
is.oneOf(value, types)

### DIFF
--- a/index.js
+++ b/index.js
@@ -760,17 +760,22 @@ is.symbol = function (value) {
   return typeof Symbol === 'function' && toStr.call(value) === '[object Symbol]' && typeof symbolValueOf.call(value) === 'symbol';
 };
 
-is.oneOf = function (value) {
-  for (var _len = arguments.length, types = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
-    types[_key - 1] = arguments[_key];
-  }
-
-  if (!types.length) {
-    throw 'err: no types';
+/**
+ * is.oneOf
+ * Test if `value` is one of the provided `types`
+ *
+ * @param {Mixed} value value to test
+ * @param {Mixed|String[]} types types to test against
+ * @returns {boolean}
+ */
+is.oneOf = function (value, types) {
+  if (!is.array(types) || is.array.empty(types)) {
+    throw new TypeError('second argument must be an array with at least one type');
   }
 
   for (var i = 0; i < types.length; i++) {
-    if (typeof is[types[i]] === 'function' && is[types[i]](value)) {
+    var fn = is[types[i]];
+    if (is.function(fn) && fn(value)) {
       return true;
     }
   }

--- a/test/index.js
+++ b/test/index.js
@@ -636,8 +636,8 @@ test('is.symbol', function (t) {
 });
 
 test('is.oneOf', function (t) {
-  t.ok(is.oneOf('foo', 'object', 'array', 'string'), 'oneOf returns true when a match is found');
-  t.notOk(is.oneOf('foo', 'number', 'fn', 'regexp'), 'oneOf returns false when no match is found');
-  t.throws(function() { is.oneOf('foo') }, /err: no types/i, 'throws when called with no types');
+  t.ok(is.oneOf('foo', ['object', 'array', 'string']), 'oneOf returns true when a match is found');
+  t.notOk(is.oneOf('foo', ['number', 'fn', 'regexp']), 'oneOf returns false when no match is found');
+  t.throws(function() { is.oneOf('foo') }, /array with at least one type/i, 'throws when called with no types');
   t.end();
 });


### PR DESCRIPTION
Allows for checking multiple types in a single call.

Example:
```javascript
is.oneOf('foo', ['object', 'array', 'string']) // true
is.oneOf('foo', ['number', 'regexp', 'fn']) // false
```